### PR TITLE
new: add support for non-master branches

### DIFF
--- a/approvers.go
+++ b/approvers.go
@@ -58,8 +58,8 @@ func processApprovers(v reflect.Value, out *map[string][]string) error {
 	return nil
 }
 
-func getApprovers(ownersClient *repoowners.Client, org, repo string, dedupe bool) (map[string][]string, error) {
-	owners, err := ownersClient.LoadRepoOwners(org, repo, "master")
+func getApprovers(ownersClient *repoowners.Client, org, repo, branch string, dedupe bool) (map[string][]string, error) {
+	owners, err := ownersClient.LoadRepoOwners(org, repo, branch)
 	if err != nil {
 		logrus.WithError(err).WithField("organization", org).WithField("repository", repo).Fatal("Unable to fetch OWNERS.")
 	}
@@ -82,7 +82,7 @@ func getApprovers(ownersClient *repoowners.Client, org, repo string, dedupe bool
 			if v != "" {
 				v = fmt.Sprintf("/%s", v)
 			}
-			newvalues = append(newvalues, fmt.Sprintf("%s/%s%s", org, repo, v))
+			newvalues = append(newvalues, fmt.Sprintf("%s/%s:%s%s", org, repo, branch, v))
 		}
 		result[k] = newvalues
 	}

--- a/maintainers.go
+++ b/maintainers.go
@@ -51,8 +51,9 @@ func getMaintainers(ghClient github.Client, gitClient *git.Client, opts *Options
 		}
 	} else {
 		repos = append(repos, Repository{
-			Org:  opts.org,
-			Repo: opts.repo,
+			Org:    opts.org,
+			Repo:   opts.repo,
+			Branch: opts.branch,
 		})
 	}
 
@@ -72,7 +73,7 @@ func getMaintainers(ghClient github.Client, gitClient *git.Client, opts *Options
 	// Get approvers from OWNER files for every repo
 	maintainers := map[string][]string{}
 	for _, v := range repos {
-		approvers, err := getApprovers(ownersClient, v.Org, v.Repo, opts.dedupe)
+		approvers, err := getApprovers(ownersClient, v.Org, v.Repo, v.Branch, opts.dedupe)
 		if err != nil {
 			logrus.WithField("organization", v.Org).WithField("repository", v.Repo).Error(err)
 		}
@@ -125,7 +126,9 @@ func getMaintainers(ghClient github.Client, gitClient *git.Client, opts *Options
 		for _, p := range projects {
 			parts := strings.Split(p, "/")
 			if len(parts) > 2 {
-				parts[2] = fmt.Sprintf("tree/master/%s", parts[2])
+				repoparts := strings.Split(parts[1], ":")
+				parts[1] = repoparts[0]
+				parts[2] = fmt.Sprintf("tree/%s/%s", repoparts[1], parts[2])
 			}
 			p = strings.Join(parts[:], "/")
 			m.Projects = append(m.Projects, fmt.Sprintf("%s/%s", host, p))

--- a/options.go
+++ b/options.go
@@ -19,6 +19,7 @@ type Options struct {
 	logLevel       string
 	org            string
 	repo           string
+	branch         string
 	dedupe         bool
 	sort           bool
 	personsFile    string
@@ -77,6 +78,7 @@ func NewOptions() *Options {
 	fs.StringVar(&o.logLevel, "log-level", "info", "Log level.")
 	fs.StringVar(&o.org, "org", "", "The GitHub organization name.")
 	fs.StringVar(&o.repo, "repo", "", "The GitHub repository name.")
+	fs.StringVar(&o.branch, "branch", "master", "The repository branch name (only used if repo is specified).")
 	fs.StringVar(&o.personsFile, "persons-db", "data/data.json", "The path to a JSON file containing handle => name/company mappings")
 	fs.StringVar(&o.outputFile, "output", "stdout", "The path where to write the output YAML maintainers")
 	fs.BoolVar(&o.banner, "banner", false, "Whether you want a header on top of the output YAML maintainers file")

--- a/repositories.go
+++ b/repositories.go
@@ -8,8 +8,9 @@ import (
 
 // Repository represents the full name of a repo.
 type Repository struct {
-	Org  string
-	Repo string
+	Org    string
+	Repo   string
+	Branch string
 }
 
 func getRepositories(ghClient github.Client, org string) ([]Repository, error) {
@@ -29,8 +30,9 @@ func getRepositories(ghClient github.Client, org string) ([]Repository, error) {
 			continue
 		}
 		repos = append(repos, Repository{
-			Org:  org,
-			Repo: v.Name,
+			Org:    org,
+			Repo:   v.Name,
+			Branch: v.DefaultBranch,
 		})
 	}
 	if len(repos) == 0 {


### PR DESCRIPTION
This PR adds support for repos that have a default branch which is not `master`.

This is especially needed after https://github.blog/changelog/2020-10-01-the-default-branch-for-newly-created-repositories-is-now-main/.

Signed-off-by: Michele Zuccala <michele@zuccala.com>